### PR TITLE
add org-ids to elasticsearch mapping #13

### DIFF
--- a/data_import/import_data.py
+++ b/data_import/import_data.py
@@ -209,8 +209,6 @@ def import_extract_charity(chars={},
                 if ccount % 10000 == 0:
                     print('\r', "[CCEW] %s charities read from extract_charity.csv (main pass)" % ccount, end='')
 
-        char_json['org-ids'] = add_org_id_prefix(char_json)
-
         print('\r', "[CCEW] %s charities read from extract_charity.csv (main pass)" % ccount)
 
         ccount = 0
@@ -245,6 +243,7 @@ def import_extract_main(chars={}, datafile=os.path.join("data", "ccew", "extract
                         "url": "http://beta.companieshouse.gov.uk/company/" + parse_company_number(row[1]),
                         "source": "ccew"
                     })
+                    chars[row[0]]['org-ids'] = add_org_id_prefix(chars[row[0]])
                 if row[9]:
                     chars[row[0]]["url"] = row[9]
                 if row[6]:
@@ -394,7 +393,7 @@ def import_oscr(chars={},
             if ccount % 10000 == 0:
                 print('\r', "[OSCR] %s charities added or updated from oscr.csv" % ccount, end='')
 
-        char_json['org-ids'] = add_org_id_prefix(char_json)
+            char_json['org-ids'] = add_org_id_prefix(char_json)
 
         print('\r', "[OSCR] %s charities added or updated from oscr.csv" % ccount)
         print('\r', "[OSCR] %s charities added from oscr.csv" % cadded)

--- a/data_import/import_data.py
+++ b/data_import/import_data.py
@@ -90,6 +90,18 @@ def parse_ni_charity_number(charno):
         return "NIC" + charno
     return charno
 
+def add_org_id_prefix(char_json):
+    prefixes = []
+    if char_json['company_number']:
+        for coh in char_json['company_number']:
+            prefixes.append('GB-COH-' + coh['number'])
+    if char_json['oscr_number']:
+        prefixes.append('GB-SC-' + char_json['oscr_number'])
+    if char_json['ccew_number']:
+        prefixes.append('GB-CHC-' + char_json['ccew_number'])
+    if char_json['ccni_number']:
+        prefixes.append('GB-NIC-' + char_json['ccni_number'])
+    return prefixes
 
 def parse_url(url):
     if url is None:
@@ -196,6 +208,9 @@ def import_extract_charity(chars={},
                 ccount += 1
                 if ccount % 10000 == 0:
                     print('\r', "[CCEW] %s charities read from extract_charity.csv (main pass)" % ccount, end='')
+
+        char_json['org-ids'] = add_org_id_prefix(char_json)
+
         print('\r', "[CCEW] %s charities read from extract_charity.csv (main pass)" % ccount)
 
         ccount = 0
@@ -378,6 +393,9 @@ def import_oscr(chars={},
             ccount += 1
             if ccount % 10000 == 0:
                 print('\r', "[OSCR] %s charities added or updated from oscr.csv" % ccount, end='')
+
+        char_json['org-ids'] = add_org_id_prefix(char_json)
+
         print('\r', "[OSCR] %s charities added or updated from oscr.csv" % ccount)
         print('\r', "[OSCR] %s charities added from oscr.csv" % cadded)
         print('\r', "[OSCR] %s charities updated using oscr.csv" % cupdated)
@@ -488,6 +506,9 @@ def import_ccni(chars={},
 
                 chars[row["Reg charity number"]] = char_json
                 cadded += 1
+
+            char_json['org-ids'] = add_org_id_prefix(char_json)
+
             ccount += 1
             if ccount % 10000 == 0:
                 print('\r', "[CCNI] %s charities added or updated from ccni.csv" % ccount, end='')

--- a/readme.md
+++ b/readme.md
@@ -6,6 +6,7 @@ Elasticsearch-powered search engine for looking for charities. Allows for:
 - importing data from England and Wales, Scotland, and Northern Ireland, ensuring that duplicates
   are matched to one record.
 - An elasticsearch index that can be queried.
+- [Org-ids](http://org-id.guide/about) are added to charities.
 - Reconciliation API for searching charity, based on an optimised search query.
 - Facility for uploading a CSV of charity names and adding the (best guess) at a
   charity number.
@@ -95,7 +96,7 @@ The data is imported into elasticsearch in the following format:
   "charity_number": "12355",
   "ccew_number": "12355",
   "oscr_number": "SC1235",
-  "ccni_number": "NI100012",
+  "ccni_number": "NIC100012",
   "active": true,
   "names": [
     {"name": "Charity Name", "type": "registered name", "source": "ccew"}
@@ -115,7 +116,8 @@ The data is imported into elasticsearch in the following format:
   "parent": "124566",
   "ccew_link": "http://apps.charitycommission.gov.uk/Showcharity/RegisterOfCharities/SearchResultHandler.aspx?RegisteredCharityNumber=12355&SubsidiaryNumber=0",
   "oscr_link": "http://www.oscr.org.uk/charities/search-scottish-charity-register/charity-details?number=SC1235",
-  "ccni_link": "http://www.charitycommissionni.org.uk/charity-details/?regid=100012&subid=0"
+  "ccni_link": "http://www.charitycommissionni.org.uk/charity-details/?regid=100012&subid=0",
+  "org-ids": ["GB-COH-00121212", "GB-CHC-12355", "GB-SC-SC1235", "GB-NIC-100012"]
 }
 ```
 

--- a/views/charity.html
+++ b/views/charity.html
@@ -153,6 +153,14 @@
                 % end
                 </td>
               </tr>
+              <tr>
+                <th>Org-ids<br /><a href="http://org-id.guide/about" target="_blank" class="has-text-weight-light">What is org-id?</a></th>
+                <td>
+                  % for orgid in charity["org-ids"]:
+                      {{ orgid }}<br />
+                  % end
+                </td>
+              </tr>
             </tbody>
           </table>
         </div>

--- a/views/charity.html
+++ b/views/charity.html
@@ -156,8 +156,12 @@
               <tr>
                 <th>Org-ids<br /><a href="http://org-id.guide/about" target="_blank" class="has-text-weight-light">What is org-id?</a></th>
                 <td>
-                  % for orgid in charity["org-ids"]:
-                      {{ orgid }}<br />
+                  % if charity["org-ids"]:
+                    % for orgid in charity["org-ids"]:
+                        {{ orgid }}<br />
+                    % end
+                  % else:
+                    <code>None</code>
                   % end
                 </td>
               </tr>


### PR DESCRIPTION
Adds an array of org-id formatted (i.e. prefixed) strings for present charity numbers and company numbers.

Also displays this in the site with a link to http://org-id.guide/about.
 #13 